### PR TITLE
perf: optimize tempoross plugin

### DIFF
--- a/src/main/java/com/tempoross/DrawObject.java
+++ b/src/main/java/com/tempoross/DrawObject.java
@@ -5,9 +5,7 @@ import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import net.runelite.api.GameObject;
 import net.runelite.api.Tile;
-
 
 @Setter
 @Getter
@@ -15,7 +13,6 @@ import net.runelite.api.Tile;
 class DrawObject
 {
 	private final Tile tile;
-	private final GameObject gameObject;
 	private Instant startTime;
 	private final int duration;
 	private Color color;

--- a/src/main/java/com/tempoross/TemporossOverlay.java
+++ b/src/main/java/com/tempoross/TemporossOverlay.java
@@ -146,7 +146,7 @@ class TemporossOverlay extends Overlay
 			if (lp.distanceTo(playerLocation) < MAX_DISTANCE)
 			{
 				//testing shows a time between 20 and 27 seconds. even though it isn't fully accurate, it is still better than nothing
-				float percent = (now.toEpochMilli() - startTime.toEpochMilli()) / DOUBLE_SPOT_MOVE_MILLIS;
+				float percent = (now.toEpochMilli() - startTime) / DOUBLE_SPOT_MOVE_MILLIS;
 				ProgressPieComponent ppc = new ProgressPieComponent();
 				ppc.setBorderColor(config.doubleSpotColor());
 				ppc.setFill(config.doubleSpotColor());

--- a/src/main/java/com/tempoross/TemporossOverlay.java
+++ b/src/main/java/com/tempoross/TemporossOverlay.java
@@ -86,12 +86,17 @@ class TemporossOverlay extends Overlay
 					OverlayUtil.renderPolygon(graphics, poly, drawObject.getColor());
 				}
 			}
+			if (drawObject.getDuration() <= 0 || object.getCanvasLocation() == null)
+			{
+				return;
+			}
 			if (highlightFires != TimerModes.OFF && FIRE_GAMEOBJECTS.contains(object.getId()))
 			{
-				if (drawObject.getDuration() > 0 &&
-						object.getCanvasLocation() != null &&
-						(highlightFires == TimerModes.SECONDS || highlightFires == TimerModes.TICKS) &&
-						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
+				if (tile.getLocalLocation().distanceTo(playerLocation) >= MAX_DISTANCE)
+				{
+					return;
+				}
+				if (highlightFires == TimerModes.SECONDS || highlightFires == TimerModes.TICKS)
 				{
 					long waveTimerMillis = (drawObject.getStartTime().toEpochMilli() + drawObject.getDuration()) - now.toEpochMilli();
 					//modulo to recalculate fires timer after they spread
@@ -99,29 +104,24 @@ class TemporossOverlay extends Overlay
 
 					renderTextElement(object, drawObject, waveTimerMillis, graphics, highlightFires);
 				}
-				else if (drawObject.getDuration() > 0 &&
-						object.getCanvasLocation() != null &&
-						highlightFires == TimerModes.PIE &&
-						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
+				else if (highlightFires == TimerModes.PIE)
 				{
 					renderPieElement(object, drawObject, now, graphics);
 				}
 			}
 			else if (waveTimer != TimerModes.OFF && TETHER_GAMEOBJECTS.contains(object.getId())) //Wave and is not OFF
 			{
-				if (drawObject.getDuration() > 0 &&
-						object.getCanvasLocation() != null &&
-						(waveTimer == TimerModes.SECONDS || waveTimer == TimerModes.TICKS) &&
-						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
+				if (tile.getLocalLocation().distanceTo(playerLocation) >= MAX_DISTANCE)
+				{
+					return;
+				}
+				if (waveTimer == TimerModes.SECONDS || waveTimer == TimerModes.TICKS)
 				{
 					long waveTimerMillis = (drawObject.getStartTime().toEpochMilli() + drawObject.getDuration()) - now.toEpochMilli();
 
 					renderTextElement(object, drawObject, waveTimerMillis, graphics, waveTimer);
 				}
-				else if (drawObject.getDuration() > 0 &&
-						object.getCanvasLocation() != null &&
-						waveTimer == TimerModes.PIE &&
-						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
+				else if (waveTimer == TimerModes.PIE)
 				{
 					renderPieElement(object, drawObject, now, graphics);
 				}

--- a/src/main/java/com/tempoross/TemporossOverlay.java
+++ b/src/main/java/com/tempoross/TemporossOverlay.java
@@ -69,11 +69,14 @@ class TemporossOverlay extends Overlay
 
 	private void highlightGameObjects(Graphics2D graphics, LocalPoint playerLocation, Instant now)
 	{
+		final int plane = client.getPlane();
+		final TimerModes highlightFires = config.highlightFires();
+		final TimerModes waveTimer = config.useWaveTimer();
 		plugin.getGameObjects().forEach((object, drawObject) ->
 		{
 			Tile tile = drawObject.getTile();
 
-			if (tile.getPlane() == client.getPlane()
+			if (tile.getPlane() == plane
 				&& tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
 			{
 				Polygon poly = object.getCanvasTilePoly();
@@ -83,38 +86,42 @@ class TemporossOverlay extends Overlay
 					OverlayUtil.renderPolygon(graphics, poly, drawObject.getColor());
 				}
 			}
-			if (FIRE_GAMEOBJECTS.contains(object.getId()) && config.highlightFires() != TimerModes.OFF)
+			if (highlightFires != TimerModes.OFF && FIRE_GAMEOBJECTS.contains(object.getId()))
 			{
 				if (drawObject.getDuration() > 0 &&
 						object.getCanvasLocation() != null &&
-						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE && (config.highlightFires() == TimerModes.SECONDS || config.highlightFires() == TimerModes.TICKS))
+						(highlightFires == TimerModes.SECONDS || highlightFires == TimerModes.TICKS) &&
+						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
 				{
 					long waveTimerMillis = (drawObject.getStartTime().toEpochMilli() + drawObject.getDuration()) - now.toEpochMilli();
 					//modulo to recalculate fires timer after they spread
 					waveTimerMillis = (((waveTimerMillis % drawObject.getDuration()) + drawObject.getDuration()) % drawObject.getDuration());
 
-					renderTextElement(object, drawObject, waveTimerMillis, graphics, config.highlightFires());
+					renderTextElement(object, drawObject, waveTimerMillis, graphics, highlightFires);
 				}
 				else if (drawObject.getDuration() > 0 &&
 						object.getCanvasLocation() != null &&
-						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE && config.highlightFires() == TimerModes.PIE)
+						highlightFires == TimerModes.PIE &&
+						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
 				{
 					renderPieElement(object, drawObject, now, graphics);
 				}
 			}
-			else if (TETHER_GAMEOBJECTS.contains(object.getId()) && config.useWaveTimer() != TimerModes.OFF) //Wave and is not OFF
+			else if (waveTimer != TimerModes.OFF && TETHER_GAMEOBJECTS.contains(object.getId())) //Wave and is not OFF
 			{
 				if (drawObject.getDuration() > 0 &&
 						object.getCanvasLocation() != null &&
-						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE && (config.useWaveTimer() == TimerModes.SECONDS || config.useWaveTimer() == TimerModes.TICKS))
+						(waveTimer == TimerModes.SECONDS || waveTimer == TimerModes.TICKS) &&
+						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
 				{
 					long waveTimerMillis = (drawObject.getStartTime().toEpochMilli() + drawObject.getDuration()) - now.toEpochMilli();
 
-					renderTextElement(object, drawObject, waveTimerMillis, graphics, config.useWaveTimer());
+					renderTextElement(object, drawObject, waveTimerMillis, graphics, waveTimer);
 				}
 				else if (drawObject.getDuration() > 0 &&
 						object.getCanvasLocation() != null &&
-						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE && config.useWaveTimer() == TimerModes.PIE)
+						waveTimer == TimerModes.PIE &&
+						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
 				{
 					renderPieElement(object, drawObject, now, graphics);
 				}

--- a/src/main/java/com/tempoross/TemporossOverlay.java
+++ b/src/main/java/com/tempoross/TemporossOverlay.java
@@ -69,9 +69,8 @@ class TemporossOverlay extends Overlay
 
 	private void highlightGameObjects(Graphics2D graphics, LocalPoint playerLocation, Instant now)
 	{
-		plugin.getGameObjects().values().forEach((drawObject) ->
+		plugin.getGameObjects().forEach((object, drawObject) ->
 		{
-			GameObject object = drawObject.getGameObject();
 			Tile tile = drawObject.getTile();
 
 			if (tile.getPlane() == client.getPlane()
@@ -84,40 +83,40 @@ class TemporossOverlay extends Overlay
 					OverlayUtil.renderPolygon(graphics, poly, drawObject.getColor());
 				}
 			}
-			if (FIRE_GAMEOBJECTS.contains(drawObject.getGameObject().getId()) && config.highlightFires() != TimerModes.OFF)
+			if (FIRE_GAMEOBJECTS.contains(object.getId()) && config.highlightFires() != TimerModes.OFF)
 			{
 				if (drawObject.getDuration() > 0 &&
-						drawObject.getGameObject().getCanvasLocation() != null &&
+						object.getCanvasLocation() != null &&
 						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE && (config.highlightFires() == TimerModes.SECONDS || config.highlightFires() == TimerModes.TICKS))
 				{
 					long waveTimerMillis = (drawObject.getStartTime().toEpochMilli() + drawObject.getDuration()) - now.toEpochMilli();
 					//modulo to recalculate fires timer after they spread
 					waveTimerMillis = (((waveTimerMillis % drawObject.getDuration()) + drawObject.getDuration()) % drawObject.getDuration());
 
-					renderTextElement(drawObject, waveTimerMillis, graphics, config.highlightFires());
+					renderTextElement(object, drawObject, waveTimerMillis, graphics, config.highlightFires());
 				}
 				else if (drawObject.getDuration() > 0 &&
-						drawObject.getGameObject().getCanvasLocation() != null &&
+						object.getCanvasLocation() != null &&
 						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE && config.highlightFires() == TimerModes.PIE)
 				{
-					renderPieElement(drawObject, now, graphics);
+					renderPieElement(object, drawObject, now, graphics);
 				}
 			}
-			else if (TETHER_GAMEOBJECTS.contains(drawObject.getGameObject().getId()) && config.useWaveTimer() != TimerModes.OFF) //Wave and is not OFF
+			else if (TETHER_GAMEOBJECTS.contains(object.getId()) && config.useWaveTimer() != TimerModes.OFF) //Wave and is not OFF
 			{
 				if (drawObject.getDuration() > 0 &&
-						drawObject.getGameObject().getCanvasLocation() != null &&
+						object.getCanvasLocation() != null &&
 						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE && (config.useWaveTimer() == TimerModes.SECONDS || config.useWaveTimer() == TimerModes.TICKS))
 				{
 					long waveTimerMillis = (drawObject.getStartTime().toEpochMilli() + drawObject.getDuration()) - now.toEpochMilli();
 
-					renderTextElement(drawObject, waveTimerMillis, graphics, config.useWaveTimer());
+					renderTextElement(object, drawObject, waveTimerMillis, graphics, config.useWaveTimer());
 				}
 				else if (drawObject.getDuration() > 0 &&
-						drawObject.getGameObject().getCanvasLocation() != null &&
+						object.getCanvasLocation() != null &&
 						tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE && config.useWaveTimer() == TimerModes.PIE)
 				{
-					renderPieElement(drawObject, now, graphics);
+					renderPieElement(object, drawObject, now, graphics);
 				}
 			}
 		});
@@ -152,7 +151,7 @@ class TemporossOverlay extends Overlay
 		});
 	}
 
-	private void renderTextElement(DrawObject drawObject, long timerMillis, Graphics2D graphics, TimerModes timerMode)
+	private void renderTextElement(GameObject gameObject, DrawObject drawObject, long timerMillis, Graphics2D graphics, TimerModes timerMode)
 	{
 		final String timerText;
 		if (timerMode == TimerModes.SECONDS)
@@ -165,11 +164,11 @@ class TemporossOverlay extends Overlay
 		}
 		textComponent.setText(timerText);
 		textComponent.setColor(drawObject.getColor());
-		textComponent.setPosition(new java.awt.Point(drawObject.getGameObject().getCanvasLocation().getX(), drawObject.getGameObject().getCanvasLocation().getY()));
+		textComponent.setPosition(new java.awt.Point(gameObject.getCanvasLocation().getX(), gameObject.getCanvasLocation().getY()));
 		textComponent.render(graphics);
 	}
 
-	private void renderPieElement(DrawObject drawObject, Instant now, Graphics2D graphics)
+	private void renderPieElement(GameObject gameObject, DrawObject drawObject, Instant now, Graphics2D graphics)
 	{
 		//modulo as the fire spreads every 24 seconds
 		float percent = ((now.toEpochMilli() - drawObject.getStartTime().toEpochMilli()) % drawObject.getDuration()) / (float) drawObject.getDuration();
@@ -178,7 +177,7 @@ class TemporossOverlay extends Overlay
 		ppc.setFill(drawObject.getColor());
 		ppc.setProgress(percent);
 		ppc.setDiameter(PIE_DIAMETER);
-		ppc.setPosition(drawObject.getGameObject().getCanvasLocation());
+		ppc.setPosition(gameObject.getCanvasLocation());
 		ppc.render(graphics);
 	}
 }

--- a/src/main/java/com/tempoross/TemporossPlugin.java
+++ b/src/main/java/com/tempoross/TemporossPlugin.java
@@ -19,7 +19,7 @@ import javax.inject.Inject;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -105,7 +105,7 @@ public class TemporossPlugin extends Plugin
 	private final Map<GameObject, DrawObject> gameObjects = new WeakHashMap<>();
 
 	@Getter
-	private final Map<NPC, Instant> npcs = new HashMap<>();
+	private final Map<NPC, Long> npcs = new IdentityHashMap<>();
 
 	private final Map<GameObject, DrawObject> totemMap = new WeakHashMap<>();
 
@@ -219,7 +219,7 @@ public class TemporossPlugin extends Plugin
 		{
 			if (config.highlightDoubleSpot())
 			{
-				npcs.put(npcSpawned.getNpc(), Instant.now());
+				npcs.put(npcSpawned.getNpc(), Instant.now().toEpochMilli());
 			}
 
 			if (config.doubleSpotNotification())

--- a/src/main/java/com/tempoross/TemporossPlugin.java
+++ b/src/main/java/com/tempoross/TemporossPlugin.java
@@ -347,33 +347,36 @@ public class TemporossPlugin extends Plugin
 
 	public void addTotemTimers(boolean setStart)
 	{
+		if (setStart && !totemMap.isEmpty())
+		{
+			this.waveIncomingStartTime = Instant.now();
+		}
+		final Instant start = this.waveIncomingStartTime;
+		final boolean tethered = client.getVarbitValue(VARB_IS_TETHERED) > 0;
 		totemMap.forEach((object, drawObject) ->
 		{
 			Color color;
-
-			switch (object.getId())
-			{
-				case ObjectID.DAMAGED_MAST_40996:
-				case ObjectID.DAMAGED_MAST_40997:
-				case ObjectID.DAMAGED_TOTEM_POLE:
-				case ObjectID.DAMAGED_TOTEM_POLE_41011:
-					color = config.poleBrokenColor();
-					break;
-				default:
-					color = config.waveTimerColor();
-			}
-
-			if (client.getVarbitValue(VARB_IS_TETHERED) > 0)
+			if (tethered)
 			{
 				color = config.tetheredColor();
 			}
-
-			if (setStart)
+			else
 			{
-				waveIncomingStartTime = Instant.now();
+				switch (object.getId())
+				{
+					case ObjectID.DAMAGED_MAST_40996:
+					case ObjectID.DAMAGED_MAST_40997:
+					case ObjectID.DAMAGED_TOTEM_POLE:
+					case ObjectID.DAMAGED_TOTEM_POLE_41011:
+						color = config.poleBrokenColor();
+						break;
+					default:
+						color = config.waveTimerColor();
+						break;
+				}
 			}
 
-			drawObject.setStartTime(waveIncomingStartTime);
+			drawObject.setStartTime(start);
 			drawObject.setColor(color);
 
 			gameObjects.put(object, drawObject);

--- a/src/main/java/com/tempoross/TemporossPlugin.java
+++ b/src/main/java/com/tempoross/TemporossPlugin.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 
 import static com.tempoross.TimerSwaps.*;
 
@@ -101,12 +102,12 @@ public class TemporossPlugin extends Plugin
 	//40996/40997 = a broken mast
 
 	@Getter
-	private final Map<GameObject, DrawObject> gameObjects = new HashMap<>();
+	private final Map<GameObject, DrawObject> gameObjects = new WeakHashMap<>();
 
 	@Getter
 	private final Map<NPC, Instant> npcs = new HashMap<>();
 
-	private final Map<GameObject, DrawObject> totemMap = new HashMap<>();
+	private final Map<GameObject, DrawObject> totemMap = new WeakHashMap<>();
 
 	private TemporossInfoBox rewardInfoBox;
 	private TemporossInfoBox fishInfoBox;
@@ -174,7 +175,7 @@ public class TemporossPlugin extends Plugin
 			default:
 				//if it is not one of the above, it is a totem/mast and should be added to the totem map, with 7800ms duration, and the regular color
 				totemMap.put(gameObjectSpawned.getGameObject(),
-						new DrawObject(gameObjectSpawned.getTile(), gameObjectSpawned.getGameObject(),
+						new DrawObject(gameObjectSpawned.getTile(),
 								Instant.now(), WAVE_IMPACT_MILLIS, config.waveTimerColor()));
 				if (waveIsIncoming && config.useWaveTimer() != TimerModes.OFF)
 				{
@@ -183,7 +184,7 @@ public class TemporossPlugin extends Plugin
 				return;
 		}
 
-		gameObjects.put(gameObjectSpawned.getGameObject(), new DrawObject(gameObjectSpawned.getTile(), gameObjectSpawned.getGameObject(), Instant.now(), duration, config.fireColor()));
+		gameObjects.put(gameObjectSpawned.getGameObject(), new DrawObject(gameObjectSpawned.getTile(), Instant.now(), duration, config.fireColor()));
 //		}
 	}
 
@@ -381,7 +382,7 @@ public class TemporossPlugin extends Plugin
 
 	public void removeTotemTimers()
 	{
-		totemMap.forEach(gameObjects::remove);
+		gameObjects.keySet().removeAll(totemMap.keySet());
 	}
 
 	private TemporossInfoBox createInfobox(BufferedImage image, String text, String tooltip)

--- a/src/main/java/com/tempoross/TemporossPlugin.java
+++ b/src/main/java/com/tempoross/TemporossPlugin.java
@@ -274,7 +274,7 @@ public class TemporossPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onVarbitChanged(VarbitChanged varbitChanged)
+	public void onClientTick(ClientTick clientTick)
 	{
 		if (nearRewardPool)
 		{


### PR DESCRIPTION
* Free `GameObject`s even earlier by holding weak references - re: #4 
* Remove unnecessary `GameObject` field from `DrawObject` (small memory savings)
* Reorder some conditional checks to reduce cpu cycles
* Switch `VarbitChanged` handler to `ClientTick` since `addTotemMaps` does not need to be called multiple times within a single tick
* and some other small tweaks
