### PR TITLE
perf: optimize tempoross ui elements

### DIFF
--- a/src/main/java/com/tempoross/TemporossPlugin.java
+++ b/src/main/java/com/tempoross/TemporossPlugin.java
@@ -407,12 +407,18 @@ public class TemporossPlugin extends Plugin
 
 	private void addRewardInfoBox(int rewardPoints)
 	{
-		infoBoxManager.removeInfoBox(rewardInfoBox);
-		rewardInfoBox = createInfobox(itemManager.getImage(REWARD_POOL_IMAGE_ID),
-			Integer.toString(rewardPoints),
-			rewardPoints + " Reward Point" + (rewardPoints == 1 ? "" : "s"));
-
-		infoBoxManager.addInfoBox(rewardInfoBox);
+		String text = Integer.toString(rewardPoints);
+		String tooltip = rewardPoints + " Reward Point" + (rewardPoints == 1 ? "" : "s");
+		if (rewardInfoBox == null)
+		{
+			rewardInfoBox = createInfobox(itemManager.getImage(REWARD_POOL_IMAGE_ID), text, tooltip);
+			infoBoxManager.addInfoBox(rewardInfoBox);
+		}
+		else
+		{
+			rewardInfoBox.setText(text);
+			rewardInfoBox.setTooltip(tooltip);
+		}
 	}
 
 	public void removeRewardInfoBox()
@@ -423,16 +429,30 @@ public class TemporossPlugin extends Plugin
 
 	public void addFishInfoBox(String text, String tooltip)
 	{
-		infoBoxManager.removeInfoBox(fishInfoBox);
-		fishInfoBox = createInfobox(itemManager.getImage(FISH_IMAGE_ID), text, tooltip);
-		infoBoxManager.addInfoBox(fishInfoBox);
+		if (fishInfoBox == null)
+		{
+			fishInfoBox = createInfobox(itemManager.getImage(FISH_IMAGE_ID), text, tooltip);
+			infoBoxManager.addInfoBox(fishInfoBox);
+		}
+		else
+		{
+			fishInfoBox.setText(text);
+			fishInfoBox.setTooltip(tooltip);
+		}
 	}
 
 	public void addTotalFishInfoBox(String text, String tooltip)
 	{
-		infoBoxManager.removeInfoBox(totalFishInfoBox);
-		totalFishInfoBox = createInfobox(itemManager.getImage(NET_IMAGE_ID), text, tooltip);
-		infoBoxManager.addInfoBox(totalFishInfoBox);
+		if (totalFishInfoBox == null)
+		{
+			totalFishInfoBox = createInfobox(itemManager.getImage(NET_IMAGE_ID), text, tooltip);
+			infoBoxManager.addInfoBox(totalFishInfoBox);
+		}
+		else
+		{
+			totalFishInfoBox.setText(text);
+			totalFishInfoBox.setTooltip(tooltip);
+		}
 	}
 
 	public void removeFishInfoBox()
@@ -449,9 +469,18 @@ public class TemporossPlugin extends Plugin
 
 	public void addDamageInfoBox(int damage)
 	{
-		infoBoxManager.removeInfoBox(damageInfoBox);
-		damageInfoBox = createInfobox(itemManager.getImage(DAMAGE_IMAGE_ID), Integer.toString(damage), "Damage: " + damage);
-		infoBoxManager.addInfoBox(damageInfoBox);
+		String text = Integer.toString(damage);
+		String tooltip = "Damage: " + damage;
+		if (damageInfoBox == null)
+		{
+			damageInfoBox = createInfobox(itemManager.getImage(DAMAGE_IMAGE_ID), text, tooltip);
+			infoBoxManager.addInfoBox(damageInfoBox);
+		}
+		else
+		{
+			damageInfoBox.setText(text);
+			damageInfoBox.setTooltip(tooltip);
+		}
 	}
 
 	public void removeDamageInfoBox()
@@ -462,9 +491,18 @@ public class TemporossPlugin extends Plugin
 
 	public void addPhaseInfoBox(int phase)
 	{
-		infoBoxManager.removeInfoBox(phaseInfoBox);
-		phaseInfoBox = createInfobox(PHASE_IMAGE, Integer.toString(phase), "Phase " + phase);
-		infoBoxManager.addInfoBox(phaseInfoBox);
+		String text = Integer.toString(phase);
+		String tooltip = "Phase " + phase;
+		if (phaseInfoBox == null)
+		{
+			phaseInfoBox = createInfobox(PHASE_IMAGE, text, tooltip);
+			infoBoxManager.addInfoBox(phaseInfoBox);
+		}
+		else
+		{
+			phaseInfoBox.setText(text);
+			phaseInfoBox.setTooltip(tooltip);
+		}
 	}
 
 	public void removePhaseInfoBox()

--- a/src/main/java/com/tempoross/TemporossPlugin.java
+++ b/src/main/java/com/tempoross/TemporossPlugin.java
@@ -274,13 +274,17 @@ public class TemporossPlugin extends Plugin
 	}
 
 	@Subscribe
+	public void onVarbitChanged(VarbitChanged event)
+	{
+		if (event.getVarbitId() == VARB_REWARD_POOL_NUMBER && nearRewardPool)
+		{
+			this.addRewardInfoBox(event.getValue());
+		}
+	}
+
+	@Subscribe
 	public void onClientTick(ClientTick clientTick)
 	{
-		if (nearRewardPool)
-		{
-			addRewardInfoBox();
-		}
-
 		// The varb is a bitfield that refers to what totem/mast the player is tethered to,
 		// with each bit corresponding to a different object, so when tethered, the totem color should update
 		if (waveIsIncoming && config.useWaveTimer() != TimerModes.OFF)
@@ -398,7 +402,11 @@ public class TemporossPlugin extends Plugin
 
 	public void addRewardInfoBox()
 	{
-		int rewardPoints = client.getVarbitValue(VARB_REWARD_POOL_NUMBER);
+		this.addRewardInfoBox(client.getVarbitValue(VARB_REWARD_POOL_NUMBER));
+	}
+
+	private void addRewardInfoBox(int rewardPoints)
+	{
 		infoBoxManager.removeInfoBox(rewardInfoBox);
 		rewardInfoBox = createInfobox(itemManager.getImage(REWARD_POOL_IMAGE_ID),
 			Integer.toString(rewardPoints),

--- a/src/main/java/com/tempoross/TemporossPlugin.java
+++ b/src/main/java/com/tempoross/TemporossPlugin.java
@@ -276,20 +276,21 @@ public class TemporossPlugin extends Plugin
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged event)
 	{
-		if (event.getVarbitId() == VARB_REWARD_POOL_NUMBER && nearRewardPool)
+		if (event.getVarbitId() == VARB_REWARD_POOL_NUMBER)
 		{
-			this.addRewardInfoBox(event.getValue());
+			if (nearRewardPool)
+			{
+				this.addRewardInfoBox(event.getValue());
+			}
 		}
-	}
-
-	@Subscribe
-	public void onClientTick(ClientTick clientTick)
-	{
-		// The varb is a bitfield that refers to what totem/mast the player is tethered to,
-		// with each bit corresponding to a different object, so when tethered, the totem color should update
-		if (waveIsIncoming && config.useWaveTimer() != TimerModes.OFF)
+		else if (event.getVarbitId() == VARB_IS_TETHERED)
 		{
-			addTotemTimers(false);
+			// The varb is a bitfield that refers to what totem/mast the player is tethered to,
+			// with each bit corresponding to a different object, so when tethered, the totem color should update
+			if (waveIsIncoming && config.useWaveTimer() != TimerModes.OFF)
+			{
+				addTotemTimers(false);
+			}
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #7

* Avoid unnecessary `InfoBoxManager` calls (`removeInfoBox` and `addInfoBox` are both *synchronized* $O(n)$ operations)
* Don't recreate reward info box every tick; only update when the corresponding varbit changes
* Don't repeatedly call `addTotemTimers` on every client tick with an incoming wave; only update when the tethered varbit changes
